### PR TITLE
Fix narrowing conversions in citymania highlight

### DIFF
--- a/src/citymania/cm_highlight.cpp
+++ b/src/citymania/cm_highlight.cpp
@@ -592,13 +592,15 @@ void ObjectHighlight::UpdateTiles() {
             ).test();
             auto palette = (this->cost.Succeeded() ? CM_PALETTE_TINT_WHITE : CM_PALETTE_TINT_RED_DEEP);
 
-		const auto layout_numtracks = std::min<uint16_t>(numtracks, UINT8_MAX);
-		const auto layout_platform_length = std::min<uint16_t>(plat_len, UINT8_MAX);
-		RailStationTileLayout stl{
-			nullptr,
-			static_cast<uint8_t>(layout_numtracks),
-			static_cast<uint8_t>(layout_platform_length)
-		};  // TODO statspec
+            const auto layout_numtracks = std::min<uint16_t>(numtracks, UINT8_MAX);
+            const auto layout_platform_length = std::min<uint16_t>(plat_len, UINT8_MAX);
+            const auto layout_numtracks8 = static_cast<uint8_t>(layout_numtracks);
+            const auto layout_platform_length8 = static_cast<uint8_t>(layout_platform_length);
+            RailStationTileLayout stl{
+                    nullptr,
+                    layout_numtracks8,
+                    layout_platform_length8
+            };  // TODO statspec
             auto it = stl.begin();
 
             auto tile_delta = (this->axis == AXIS_X ? TileDiffXY(1, 0) : TileDiffXY(0, 1));
@@ -1475,7 +1477,16 @@ void DrawSignal(SpriteID palette, const TileInfo *ti, RailType railtype, uint po
         sprite += type * 16 + variant * 64 + image * 2 + condition + (type > SIGTYPE_LAST_NOPBS ? 64 : 0);
     }
 
-    AddSortableSpriteToDraw(sprite, palette, x, y, GetSaveSlopeZ(x, y, track), {{}, {1, 1, BB_HEIGHT_UNDER_BRIDGE}, {}});
+    const SpriteBounds highlight_bounds{
+            Coord3D<int8_t>{},
+            Coord3D<uint8_t>{
+                    static_cast<uint8_t>(1),
+                    static_cast<uint8_t>(1),
+                    static_cast<uint8_t>(BB_HEIGHT_UNDER_BRIDGE)
+            },
+            Coord3D<int8_t>{}
+    };
+    AddSortableSpriteToDraw(sprite, palette, x, y, GetSaveSlopeZ(x, y, track), highlight_bounds);
 }
 
 // copied from tunnelbridge_cmd.cpp
@@ -1500,16 +1511,16 @@ void DrawBridgeHead(SpriteID palette, const TileInfo *ti, RailType railtype, Dia
     if (ti->tileh == SLOPE_FLAT) base_offset += 4; // sloped bridge head
     psid = &GetBridgeSpriteTable(type, BRIDGE_PIECE_HEAD)[base_offset];
 
-	const SpriteBounds bridge_bounds{
-		Coord3D<int8_t>{},
-		Coord3D<uint8_t>{
-			static_cast<uint8_t>(16),
-			static_cast<uint8_t>(16),
-			static_cast<uint8_t>(ti->tileh == SLOPE_FLAT ? 0 : 8)
-		},
-		Coord3D<int8_t>{}
-	};
-	AddSortableSpriteToDraw(psid->sprite, palette, ti->x, ti->y, ti->z, bridge_bounds);
+        const SpriteBounds bridge_bounds{
+                Coord3D<int8_t>{},
+                Coord3D<uint8_t>{
+                        static_cast<uint8_t>(16),
+                        static_cast<uint8_t>(16),
+                        static_cast<uint8_t>(ti->tileh == SLOPE_FLAT ? 0 : 8)
+                },
+                Coord3D<int8_t>{}
+        };
+        AddSortableSpriteToDraw(psid->sprite, palette, ti->x, ti->y, ti->z, bridge_bounds);
     // DrawAutorailSelection(ti, (ddir == DIAGDIR_SW || ddir == DIAGDIR_NE ? HT_DIR_X : HT_DIR_Y), PAL_NONE);
 }
 


### PR DESCRIPTION
## Summary
- clamp rail station layout dimensions before creating the iterator
- replace brace initializers with explicit SpriteBounds helpers to avoid narrowing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de47ac77bc83218fab01e01aabcd0c