### PR TITLE
Fix narrowing conversions in Citymania highlight helpers

### DIFF
--- a/src/citymania/cm_blueprint.cpp
+++ b/src/citymania/cm_blueprint.cpp
@@ -255,7 +255,11 @@ std::multimap<TileIndex, ObjectTileHighlight> Blueprint::GetTiles(TileIndex tile
                 add_tile(otile, ObjectTileHighlight::make_rail_depot(palette, o.u.rail.depot.ddir));
                 break;
             case Item::Type::RAIL_STATION_PART: {
-                RailStationTileLayout stl{nullptr, o.u.rail.station_part.numtracks, o.u.rail.station_part.plat_len};  // TODO statspec
+                RailStationTileLayout stl(
+                        nullptr,
+                        static_cast<uint8_t>(o.u.rail.station_part.numtracks),
+                        static_cast<uint8_t>(o.u.rail.station_part.plat_len)
+                );  // TODO statspec
                 auto it = stl.begin();
 
                 if (palette == CM_PALETTE_TINT_WHITE && can_build_station_sign.find(o.u.rail.station_part.id) == can_build_station_sign.end())

--- a/src/citymania/cm_highlight.cpp
+++ b/src/citymania/cm_highlight.cpp
@@ -592,15 +592,13 @@ void ObjectHighlight::UpdateTiles() {
             ).test();
             auto palette = (this->cost.Succeeded() ? CM_PALETTE_TINT_WHITE : CM_PALETTE_TINT_RED_DEEP);
 
-            const auto layout_numtracks = std::min<uint16_t>(numtracks, UINT8_MAX);
-            const auto layout_platform_length = std::min<uint16_t>(plat_len, UINT8_MAX);
-            const auto layout_numtracks8 = static_cast<uint8_t>(layout_numtracks);
-            const auto layout_platform_length8 = static_cast<uint8_t>(layout_platform_length);
-            RailStationTileLayout stl{
+            const auto layout_numtracks8 = static_cast<uint8_t>(std::min<uint16_t>(numtracks, UINT8_MAX));
+            const auto layout_platform_length8 = static_cast<uint8_t>(std::min<uint16_t>(plat_len, UINT8_MAX));
+            RailStationTileLayout stl(
                     nullptr,
                     layout_numtracks8,
                     layout_platform_length8
-            };  // TODO statspec
+            );  // TODO statspec
             auto it = stl.begin();
 
             auto tile_delta = (this->axis == AXIS_X ? TileDiffXY(1, 0) : TileDiffXY(0, 1));
@@ -766,7 +764,7 @@ void ObjectHighlight::UpdateTiles() {
                         ObjectTileHighlight::make_industry_tile(
                             CM_PALETTE_TINT_WHITE,
                             this->ind_type,
-							static_cast<uint8>(cost.cm.industry_layout),
+                             static_cast<uint8_t>(cost.cm.industry_layout),
                             tile_diff,
                             it.gfx
                         )


### PR DESCRIPTION
## Summary
- clamp rail station layout dimensions to uint8_t before creating layout iterators
- cast industry layout indexes to uint8_t when building highlight tiles
- ensure blueprint rail station parts construct layouts with explicit uint8_t counts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de6697b79c8321815b773f89f418ab